### PR TITLE
ArticleCardのLink化およびpathの追加

### DIFF
--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,10 +1,10 @@
 // ディレクトリ（ドメイン）ごとにオブジェクトを作成する
 const BASE = {
-  home: '/',
+  HOME: '/',
 } as const satisfies Record<string, `/${string}`>;
 
 const ARTICLES = {
-  articleDetail: (id) => `/articles/${id}`,
+  ARTICLE_DETAIL: (id) => `/articles/${id}`,
 } as const satisfies Record<string, (id: string) => `/articles/${string}`>;
 
 // ディレクトリ（ドメイン）ごとのオブジェクトをpath内でマージする

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -5,10 +5,7 @@ const BASE = {
 
 const ARTICLES = {
   articleDetail: (id) => `/articles/${id}`,
-} as const satisfies Record<
-  string,
-  `/articles/${string}` | ((id: string) => `/articles/${string}`)
->;
+} as const satisfies Record<string, (id: string) => `/articles/${string}`>;
 
 // ディレクトリ（ドメイン）ごとのオブジェクトをpath内でマージする
 export const path = {

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,13 +1,16 @@
-// ディレクトリごとにオブジェクトを作成する
+// ディレクトリ（ドメイン）ごとにオブジェクトを作成する
 const BASE = {
   home: '/',
 } as const satisfies Record<string, `/${string}`>;
 
 const ARTICLES = {
   articleDetail: (id) => `/articles/${id}`,
-} as const satisfies Record<string, (id: string) => `/articles/${string}`>;
+} as const satisfies Record<
+  string,
+  `/articles/${string}` | ((id: string) => `/articles/${string}`)
+>;
 
-// ディレクトリごとのオブジェクトをpath内でマージする
+// ディレクトリ（ドメイン）ごとのオブジェクトをpath内でマージする
 export const path = {
   ...BASE,
   ...ARTICLES,

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,14 @@
+// ディレクトリごとにオブジェクトを作成する
+const BASE = {
+  home: '/',
+} as const satisfies Record<string, `/${string}`>;
+
+const ARTICLES = {
+  articleDetail: (id) => `/articles/${id}`,
+} as const satisfies Record<string, (id: string) => `/articles/${string}`>;
+
+// ディレクトリごとのオブジェクトをpath内でマージする
+export const path = {
+  ...BASE,
+  ...ARTICLES,
+} as const;

--- a/src/features/articles/components/ArticleList/index.tsx
+++ b/src/features/articles/components/ArticleList/index.tsx
@@ -1,6 +1,8 @@
 import { Article } from '@/types/article';
-import { container } from './style.css';
+import { articleCardLink, container } from './style.css';
 import ArticleCard from '../ArticleCard';
+import Link from 'next/link';
+import { path } from '@/constants/path';
 
 type Props = {
   items: Article[];
@@ -10,7 +12,13 @@ export default function ArticleList({ items }: Props) {
   return (
     <div className={container}>
       {items.map((item) => (
-        <ArticleCard key={item.id} item={item} />
+        <Link
+          href={path.articleDetail(item.id)}
+          key={item.id}
+          className={articleCardLink}
+        >
+          <ArticleCard item={item} />
+        </Link>
       ))}
     </div>
   );

--- a/src/features/articles/components/ArticleList/index.tsx
+++ b/src/features/articles/components/ArticleList/index.tsx
@@ -13,7 +13,7 @@ export default function ArticleList({ items }: Props) {
     <div className={container}>
       {items.map((item) => (
         <Link
-          href={path.articleDetail(item.id)}
+          href={path.ARTICLE_DETAIL(item.id)}
           key={item.id}
           className={articleCardLink}
         >

--- a/src/features/articles/components/ArticleList/style.css.ts
+++ b/src/features/articles/components/ArticleList/style.css.ts
@@ -1,3 +1,4 @@
+import { colors } from '@/constants/colors';
 import { spacing } from '@/constants/spacing';
 import { style } from '@vanilla-extract/css';
 
@@ -6,4 +7,8 @@ export const container = style({
   height: '100%',
   display: 'flex',
   gap: spacing.xl,
+});
+
+export const articleCardLink = style({
+  color: colors.black,
 });

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,5 +1,5 @@
 export type Article = {
-  id: number;
+  id: string;
   title: string;
   content: string;
   createdAt: string;


### PR DESCRIPTION
## 概要

- `ArticleCard`を`Link`化し、それぞれのページに遷移するよう実装しました。
- それに伴い、`path`を`constants`に共通化しています。（今後`path`の使用増加が考えられるため）

## 相談・共有事項

- `develop`ブランチで他のPRを上げていたため、`feature`ブランチを切ってPRを上げています。
- 記事詳細ページのデザインは仮のものとしています。

## スクリーンショット

| 動作確認 |
| ---- |
| <video src="https://github.com/zonoryo17/zonoryo-blog-app/assets/88890984/d4bb0c9d-2ce1-4071-b06b-7c3b9001f9b6"> |
